### PR TITLE
Fix hollow step markers for is-small modifier

### DIFF
--- a/bulma-steps.sass
+++ b/bulma-steps.sass
@@ -292,8 +292,8 @@ $steps-thin-marker-size: .8em !default
   &.is-hollow,
   .steps-marker.is-hollow
     border-width: $steps-thin-divider-size
-    height: calc($steps-thin-marker-size + $steps-thin-divider-size)
-    width: calc($steps-thin-marker-size + $steps-thin-divider-size)
+    height: calc(#{$steps-thin-marker-size} + #{$steps-thin-divider-size})
+    width: calc(#{$steps-thin-marker-size} + #{$steps-thin-divider-size})
 
   +steps-vertical
     .steps-segment


### PR DESCRIPTION
This is the SASS syntax error, which makes my SASS compiler fail to compile (Rails 5.1.3 + Webpacker 3.0). It works in other compilers, like https://www.sassmeister.com/, however the values of $steps-thin-marker-size and $steps-thin-divider-size are not evaluated, so the resulting CSS still has those variables in it, not their values.

I tested this change in my project and in https://www.sassmeister.com/ (switch to SASS syntax).

Thank you!