### PR TITLE
Set main to 'bulma-steps.sass' in package configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bulma-steps-component",
   "version": "0.5.3",
   "description": "Steps component for bulma.io",
-  "main": "index.js",
+  "main": "bulma-steps.sass",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
This should help package loaders to find sass file. For example, when
using nuxt.js at the moment you need to use following config:
```js
module.exports = {
  css: [ 'bulma', 'bulma-steps-component/bulma-steps.sass' ]
};
```

After this fix one should be able to set it up like this:
```js
module.exports = {
  css: [ 'bulma', 'bulma-steps-component' ]
};
```