### PR TITLE
Adds .has-content-above

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "bulma"]
-	path = bulma
-	url = https://github.com/jgthms/bulma

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "bulma"]
+	path = bulma
+	url = https://github.com/jgthms/bulma

--- a/README.md
+++ b/README.md
@@ -2,15 +2,16 @@
 
 This is an extensions for the [Bulma CSS Framework](http://bulma.io). It adds a `steps` component to
 track progress in multi step forms or wizards.
+Original written by [aramvisser](https://github.com/aramvisser) over at [his original repo](https://aramvisser.github.io/bulma-steps)
 
-[![Steps example for a checkout form](steps-example.png)](https://aramvisser.github.io/bulma-steps)
+[![Steps example for a checkout form](steps-example.png)](https://octoshrimpy.github.io/bulma-o-steps)
 
 ## Documentation
 
-[Usage & Examples](https://aramvisser.github.io/bulma-steps)
+[Usage & Examples](https://octoshrimpy.github.io/bulma-o-steps)
 
 I'm trying to keep this working with the latest available Bulma version. Currently tracking: **bulma
-v0.5.3**. Other versions _should_ work, but no promises.
+v0.7.1**. Other versions _should_ work, but no promises.
 
 ## Installation
 
@@ -41,5 +42,6 @@ documentation by running Jekyll locally.
 
 ## Related Project
 
-There is another steps extensions for Bulma available from
-[Wikiki](https://github.com/Wikiki/bulma-steps). It even has the same name!
+There is another steps extension by
+[Wikiki](https://github.com/Wikiki/bulma-steps),
+and the original source of this one, by [aramvisser](https://aramvisser.github.io/bulma-steps)

--- a/_config.yml
+++ b/_config.yml
@@ -5,3 +5,5 @@ includes_dir: bulma/docs/_includes
 
 sass:
   sass_dir: /
+
+theme: jekyll-theme-slate

--- a/_config.yml
+++ b/_config.yml
@@ -5,5 +5,3 @@ includes_dir: bulma/docs/_includes
 
 sass:
   sass_dir: /
-
-theme: jekyll-theme-slate

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 fontawesome:   https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css
 
 exclude: [bulma/]
-includes_dir: bulma/docs/_includes
+includes_dir: _includes
 
 sass:
   sass_dir: /

--- a/_includes/anchor.html
+++ b/_includes/anchor.html
@@ -1,0 +1,10 @@
+<hr class="hr" style="margin-bottom: 0;">
+
+<h3 id="{{ include.name | slugify }}" class="title is-4 is-spaced bd-anchor-title">
+  <span class="bd-anchor-name">
+    {{ include.name }}
+  </span>
+  <a class="bd-anchor-link" href="#{{ include.name | slugify }}">
+    #
+  </a>
+</h3>

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -1,0 +1,60 @@
+<div id="meta" class="field is-grouped is-grouped-multiline">
+
+  {% if include.new %}
+    <div class="control">
+      <div class="tags">
+        <span class="tag is-primary">New!</span>
+      </div>
+    </div>
+  {% endif %}
+
+  {% if include.experimental %}
+    <div class="control">
+      <div class="tags">
+        <span class="tag is-warning">Experimental</span>
+      </div>
+    </div>
+  {% endif %}
+
+  {% if include.since %}
+    <div class="control">
+      <div class="tags has-addons">
+        <span class="tag">Since</span>
+        <span class="tag is-info">{{ include.since }}</span>
+      </div>
+    </div>
+  {% endif %}
+
+  <div class="control">
+    <div class="tags has-addons">
+      <span class="tag">Colors</span>
+      {% if include.colors %}
+        <a class="tag is-success" href="#colors">Yes</a>
+      {% else %}
+        <span class="tag is-danger">No</span>
+      {% endif %}
+    </div>
+  </div>
+
+  <div class="control">
+    <div class="tags has-addons">
+      <span class="tag">Sizes</span>
+      {% if include.sizes %}
+        <a class="tag is-success" href="#sizes">Yes</a>
+      {% else %}
+        <span class="tag is-danger">No</span>
+      {% endif %}
+    </div>
+  </div>
+
+  <div class="control">
+    <div class="tags has-addons">
+      <span class="tag">Variables</span>
+      {% if include.variables %}
+        <a class="tag is-success" href="#variables">Yes</a>
+      {% else %}
+        <span class="tag is-danger">No</span>
+      {% endif %}
+    </div>
+  </div>
+</div>

--- a/_includes/variables.html
+++ b/_includes/variables.html
@@ -1,0 +1,61 @@
+{% capture content %}
+
+  {% assign anchor_name = include.anchor_name | default: 'Variables' %}
+  {% assign tab         = include.tab         | default: page.doc-tab %}
+  {% assign subtab      = include.subtab      | default: page.doc-subtab %}
+  {% assign type        = include.type        | default: tab %}
+  {% assign data        = include.data        | default: site.data.variables[tab][subtab] %}
+  {% assign variables   = include.variables   | default: data.vars %}
+  {% assign table_class = include.table_class | default: 'is-bordered' %}
+
+  {% if include.custom_message %}
+    {{ include.custom_message }}
+  {% else %}
+    {% assign variables_link_text = "these variables" %}
+    {% capture variables_link %}
+      {% if data.file_url %}
+        <a href="{{ data.file_url }}" target="_blank">{{ variables_link_text }}</a>
+      {% else %}
+        {{ variables_link_text }}
+      {% endif %}
+    {% endcapture %}
+    You can use {{ variables_link | strip }} to <strong>customize</strong> this {{ type }}. Simply set one or multiple of these variables <em>before</em> importing Bulma. <a href="{{ site.url }}/documentation/overview/customize/">Learn how</a>.
+  {% endif %}
+
+{% endcapture %}
+
+{% include anchor.html name=anchor_name %}
+
+<div class="content">
+  <p>{{ content | strip }}</p>
+</div>
+
+<div class="table-container">
+  <table class="table {{ table_class }}">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Default value</th>
+      </tr>
+    </thead>
+    <tfoot>
+      <tr>
+        <th>Name</th>
+        <th>Default value</th>
+      </tr>
+    </tfoot>
+    <tbody>
+      {% for variable_hash in variables %}
+        {% assign variable = variable_hash[1] %}
+        <tr>
+          <td >
+            <code style="white-space: nowrap;">{{ variable.name }}</code>
+          </td>
+          <td>
+            <code>{{ variable.value }}</code>
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>

--- a/bulma-steps.sass
+++ b/bulma-steps.sass
@@ -354,8 +354,8 @@ $steps-thin-marker-size: .8em !default
     flex-direction: column-reverse
 
     .steps-content
-      margin-top: 0 !important
-      padding-top: 0 !important
+      margin-top: 0
+      padding-top: 0
       display: flex
       flex-direction: column-reverse
 

--- a/bulma-steps.sass
+++ b/bulma-steps.sass
@@ -1,6 +1,6 @@
 $steps-default-color: $grey-lighter !default
-$steps-completed-color: $primary !default
-$steps-active-color: $primary !default
+$steps-completed-color: $success !default
+$steps-active-color: $success !default
 $steps-horizontal-min-width: 10em !default
 $steps-vertical-min-height: 4em !default
 $steps-marker-size: 2 !default

--- a/bulma-steps.sass
+++ b/bulma-steps.sass
@@ -108,7 +108,8 @@ $steps-thin-marker-size: .8em !default
   .steps-marker
     height: $size * $steps-marker-size
     width: $size * $steps-marker-size
-
+    overflow: hidden
+    
   +steps-vertical
     // Draw a vertical divider
     .steps-segment:not(:last-child):after

--- a/bulma-steps.sass
+++ b/bulma-steps.sass
@@ -98,7 +98,7 @@ $steps-thin-marker-size: .8em !default
     justify-content: center
     // Position & z-index are needed to put it above the divider
     position: relative
-    z-index: 10
+    z-index: 5
 
 
 // Use a mixin to define all ratios in the same spot

--- a/bulma-steps.sass
+++ b/bulma-steps.sass
@@ -347,3 +347,22 @@ $steps-thin-marker-size: .8em !default
         right: calc(-50% + #{($steps-thin-marker-size / 2) + ($steps-thin-marker-size / 2)})
 
 
+//.has-content-above
+.steps:not(:is-vertical).has-content-above
+  .steps-segment
+    display: flex
+    flex-direction: column-reverse
+
+    .steps-content
+      margin-top: 0 !important
+      padding-top: 0 !important
+      display: flex
+      flex-direction: column-reverse
+
+    &:not(:last-child):after
+      bottom: calc(1rem - (.2em))
+      top: auto
+
+  &.has-content-centered .steps-content
+    margin-bottom: 2rem
+    padding-bottom: .2em

--- a/bulma-steps.sass
+++ b/bulma-steps.sass
@@ -151,6 +151,7 @@ $steps-thin-marker-size: .8em !default
     // Align the content with the marker
     .steps-content
       margin-left: $size * $steps-marker-size / 2
+      line-height: 1em
       &:not(:last-child)
         margin-right: -$size * $steps-marker-size / 2
 

--- a/bulma-steps.sass
+++ b/bulma-steps.sass
@@ -360,9 +360,10 @@ $steps-thin-marker-size: .8em !default
       flex-direction: column-reverse
 
     &:not(:last-child):after
-      bottom: calc(1rem - (.2em))
+      bottom:
+      bottom: calc(#{$steps-thin-marker-size / 2} - #{$steps-thin-divider-size / 2})
       top: auto
 
   &.has-content-centered .steps-content
-    margin-bottom: 2rem
+    margin-bottom: $size * $steps-marker-size
     padding-bottom: .2em

--- a/bulma-steps.sass
+++ b/bulma-steps.sass
@@ -173,6 +173,11 @@ $steps-thin-marker-size: .8em !default
         margin-left: .5em
         margin-right: .5em
         padding-top: .2em
+      
+    &.has-content-above .steps-content
+      margin-bottom: $size * $steps-marker-size
+      padding-bottom: .2em
+
 
     &:not(.is-thin)
       &.has-gaps .steps-segment, .steps-segment.has-gaps
@@ -364,7 +369,3 @@ $steps-thin-marker-size: .8em !default
     &:not(:last-child):after
       bottom: calc(#{$steps-thin-marker-size / 2} - #{$steps-thin-divider-size / 2})
       top: auto
-
-  &.has-content-centered .steps-content
-    margin-bottom: $size * $steps-marker-size
-    padding-bottom: .2em

--- a/bulma-steps.sass
+++ b/bulma-steps.sass
@@ -362,7 +362,6 @@ $steps-thin-marker-size: .8em !default
       flex-direction: column-reverse
 
     &:not(:last-child):after
-      bottom:
       bottom: calc(#{$steps-thin-marker-size / 2} - #{$steps-thin-divider-size / 2})
       top: auto
 

--- a/bulma-steps.sass
+++ b/bulma-steps.sass
@@ -65,7 +65,7 @@ $steps-thin-marker-size: .8em !default
         flex-grow: 0
         &:not(:last-child)
           min-width: $steps-horizontal-min-width
-    
+
     &.is-narrow.is-centered
       justify-content: center
 
@@ -168,7 +168,7 @@ $steps-thin-marker-size: .8em !default
         left: calc(50% - #{$size * $steps-marker-size / 2})
       .steps-content
         margin-top: $size * $steps-marker-size
-        margin-left: .5em 
+        margin-left: .5em
         margin-right: .5em
         padding-top: .2em
 
@@ -348,7 +348,7 @@ $steps-thin-marker-size: .8em !default
 
 
 //.has-content-above
-.steps:not(:is-vertical).has-content-above
+.steps:not(.is-vertical).has-content-above
   .steps-segment
     display: flex
     flex-direction: column-reverse

--- a/documentation.sass
+++ b/documentation.sass
@@ -2,7 +2,7 @@
 ---
 @charset "utf-8"
 // @import 'bulma/docs/bulma-docs.sass'
-@import 'bulma/sass/base/_all.sass'
+@import 'bulma/ bulma.sass'
 @import 'bulma-steps.sass'
 
 .hero .example

--- a/documentation.sass
+++ b/documentation.sass
@@ -1,7 +1,8 @@
 ---
 ---
 @charset "utf-8"
-@import 'bulma/docs/bulma-docs.sass'
+// @import 'bulma/docs/bulma-docs.sass'
+@import 'bulma/sass/base/_all.sass'
 @import 'bulma-steps.sass'
 
 .hero .example

--- a/documentation.sass
+++ b/documentation.sass
@@ -2,11 +2,11 @@
 ---
 @charset "utf-8"
 // @import 'bulma/docs/bulma-docs.sass'
-@import 'bulma/sass/base/_all.sass'
+@import 'bulma/bulma.sass'
 @import 'bulma-steps.sass'
 
 .hero .example
-  background-color: rgb(255,255,255)
+  background-color: $white
 
 .my-step-style
   +steps-active-segment

--- a/documentation.sass
+++ b/documentation.sass
@@ -2,11 +2,11 @@
 ---
 @charset "utf-8"
 // @import 'bulma/docs/bulma-docs.sass'
-@import 'bulma/ bulma.sass'
+@import 'bulma/sass/base/_all.sass'
 @import 'bulma-steps.sass'
 
 .hero .example
-  background-color: white
+  background-color: rgb(255,255,255)
 
 .my-step-style
   +steps-active-segment

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@ variables:
       variables=true
     %}
 
-    {% include heading.html name="Documentation" %}
+    {% include anchor.html name="Documentation" %}
 
     <div class="content">
       <p>
@@ -80,7 +80,7 @@ variables:
     {{steps_example}}
     {% endhighlight %}
 
-    {% include heading.html name="Marker Content" %}
+    {% include anchor.html name="Marker Content" %}
 
     <div class="content">
       <p>
@@ -119,7 +119,7 @@ variables:
     {{steps_marker_content_example}}
     {% endhighlight %}
 
-    {% include heading.html name="Step Content" %}
+    {% include anchor.html name="Step Content" %}
 
     <div class="content">
       <p>
@@ -284,7 +284,7 @@ variables:
     {{steps_divider_content_example}}
     {% endhighlight %}
 
-    {% include heading.html name="Colors" %}
+    {% include anchor.html name="Colors" %}
 
     <div class="content">
       <p>
@@ -375,7 +375,7 @@ variables:
       </div>
     </div>
 
-    {% include heading.html name="Sizes" %}
+    {% include anchor.html name="Sizes" %}
 
     <div class="content">
       <p>
@@ -503,7 +503,7 @@ variables:
     {{steps_thin_example}}
     {% endhighlight %}
 
-    {% include heading.html name="Narrow" %}
+    {% include anchor.html name="Narrow" %}
 
     <div class="content">
       <p>
@@ -560,7 +560,7 @@ variables:
     {{steps_narrow_example}}
     {% endhighlight %}
 
-    {% include heading.html name="Marker Style" %}
+    {% include anchor.html name="Marker Style" %}
 
     <div class="content">
       <p>
@@ -619,7 +619,7 @@ variables:
     </div>
 
 
-    {% include heading.html name="Divider Styles" %}
+    {% include anchor.html name="Divider Styles" %}
 
     <div class="content">
       <p>
@@ -736,7 +736,7 @@ variables:
       </div>
     </div>
 
-    {% include heading.html name="Alignment" %}
+    {% include anchor.html name="Alignment" %}
 
     <div class="content">
       <p>
@@ -831,7 +831,7 @@ variables:
       </div>
     </div>
 
-    {% include heading.html name="Example" %}
+    {% include anchor.html name="Example" %}
 
     <div class="content">
       <p>
@@ -854,7 +854,7 @@ variables:
         </a>
       </li>
       <li class="steps-segment">
-        <a hef=#" class="has-text-dark">
+        <a hef="#" class="has-text-dark">
           <span class="steps-marker">
             <span class="icon">
               <i class="fa fa-user"></i>
@@ -895,7 +895,7 @@ variables:
     {{steps_checkout_example}}
     {% endhighlight %}
 
-    {% include heading.html name="SASS Mixin Helpers" %}
+    {% include anchor.html name="SASS Mixin Helpers" %}
 
     <div class="content">
       <p>
@@ -981,7 +981,7 @@ variables:
 
     {% include variables.html %}
 
-    {% include heading.html name="Problems?" %}
+    {% include anchor.html name="Problems?" %}
 
     <div class="content">
       <p>

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@ variables:
   <div class="container">
     <h1 class="title">Installation</h1>
     <p>
-      This is an extensions for the <a href="http://bulma.io">Bulma CSS framework</a>. See the <a href="https://github.com/aramvisser/bulma-steps">Readme on Github</a> for installation instructions.
+      This is an extensions for the <a href="http://bulma.io">Bulma CSS framework</a>. See the <a href="https://github.com/octoshrimpy/bulma-o-steps">Readme on Github</a> for installation instructions.
     </p>
 
     <hr>

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "bulma-steps-component",
-  "version": "0.5.3",
-  "description": "Steps component for bulma.io",
+  "name": "bulma-o-steps",
+  "version": "0.5.5",
+  "description": "In-depth Steps component for Bulma.io",
   "main": "bulma-steps.sass",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/aramvisser/bulma-steps"
+    "url": "git+https://github.com/octoshrimpy/bulma-o-steps"
   },
   "keywords": [
     "Bulma",
@@ -18,10 +18,10 @@
     "steps",
     "wizard"
   ],
-  "author": "aramvisser",
+  "author": "aramvisser, octoshrimpy",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/aramvisser/bulma-steps/issues"
+    "url": "https://github.com/octoshrimpy/bulma-o-steps/issues"
   },
-  "homepage": "https://aramvisser.github.io/bulma-steps"
+  "homepage": "https://octoshrimpy.github.io/bulma-o-steps"
 }


### PR DESCRIPTION
Adds the ability to have steps above the dots, and their explanations above the step name.

New to sass, so I just appended to bottom of file.

### regular `.steps` 
![steps](https://i.imgur.com/9RGU4j5.png)

### `.has-content-centered`
![has-content-centered](https://i.imgur.com/aqy7QrS.png)

### `.is-divider-content`
![is-divider-content](https://i.imgur.com/wumGa9j.png)