### PR TITLE
fix typo on <a> element

### DIFF
--- a/index.html
+++ b/index.html
@@ -854,7 +854,7 @@ variables:
         </a>
       </li>
       <li class="steps-segment">
-        <a hef=#" class="has-text-dark">
+        <a href="#" class="has-text-dark">
           <span class="steps-marker">
             <span class="icon">
               <i class="fa fa-user"></i>


### PR DESCRIPTION
minor typo I found when copy/pasting example code